### PR TITLE
Make $tu parser more tolerant

### DIFF
--- a/MudaeFarm/MudaeState.cs
+++ b/MudaeFarm/MudaeState.cs
@@ -17,6 +17,12 @@ namespace MudaeFarm
         [JsonProperty("rolls_reset")]
         public DateTime RollsReset { get; set; } = DateTime.MaxValue;
 
+        [JsonProperty("daily_reset")]
+        public DateTime DailyReset { get; set; } = DateTime.MaxValue;
+
+        [JsonProperty("daily_reset_can")]
+        public bool CanDaily { get; set; }
+
         [JsonProperty("kakera_reset")]
         public DateTime KakeraReset { get; set; } = DateTime.MaxValue;
 
@@ -27,7 +33,7 @@ namespace MudaeFarm
         public double KakeraConsumption { get; set; }
 
         [JsonProperty("kakera_can")]
-        public bool CanKakera => KakeraPower - KakeraConsumption >= 0;
+        public bool CanKakera => KakeraPower > 0 && KakeraPower - KakeraConsumption >= 0;
 
         [JsonProperty("kakera_stock")]
         public int KakeraStock { get; set; }

--- a/MudaeFarm/TimersUpParser.cs
+++ b/MudaeFarm/TimersUpParser.cs
@@ -51,7 +51,7 @@ namespace MudaeFarm
             {
                 var line = line1.ToLowerInvariant();
 
-                if (line.Contains("claim"))
+                if (line.Contains(client.CurrentUser.Username) && line.Contains("claim"))
                 {
                     if (TryParseTime(line, out var time))
                         state.ClaimReset = now + time;
@@ -73,6 +73,16 @@ namespace MudaeFarm
                 {
                     if (TryParseTime(line, out var time))
                         state.RollsReset = now + time;
+
+                    ++parsed;
+                }
+
+                else if (line.Contains("$daily"))
+                {
+                    if (TryParseTime(line, out var time))
+                        state.DailyReset = now + time;
+
+                    state.CanDaily = line.Contains("available");
 
                     ++parsed;
                 }
@@ -117,6 +127,17 @@ namespace MudaeFarm
                     ++parsed;
                 }
 
+                else if (line.Contains("$rt"))
+                {
+                    /*
+                                        if (TryParseTime(line, out var time))
+                                            state.ResetClaimTimerReset = now + time;
+
+                                        state.CanResetClaimTimer = line.Contains("available");
+                    */
+                    ++parsed;
+                }
+
                 else if (line.Contains("$dk"))
                 {
                     if (TryParseTime(line, out var time))
@@ -126,14 +147,9 @@ namespace MudaeFarm
 
                     ++parsed;
                 }
-
-                else
-                {
-                    return false;
-                }
             }
 
-            return parsed == 8;
+            return parsed >= 7;
         }
     }
 }


### PR DESCRIPTION
Ignores unparsable lines but enforces a minimum of 7 parsed elements to avoid confusing with other messages.