### PR TITLE
Allow disabling state updates

### DIFF
--- a/MudaeFarm/AutoClaimer.cs
+++ b/MudaeFarm/AutoClaimer.cs
@@ -107,17 +107,13 @@ namespace MudaeFarm
 
             if (matched)
             {
-                // enforce always claiming if state update is disabled
-                if (!string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
-                {
-                    var state = _state.Get(guild.Id);
+                var state = _state.Get(guild.Id);
 
-                    // ensure we can claim right now
-                    if (!state.CanClaim && DateTime.Now < state.ClaimReset)
-                    {
-                        Log.Warning($"{guild} {message.Channel}: Found character '{character}' but cannot claim it due to cooldown.");
-                        return;
-                    }
+                // ensure we can claim right now
+                if (!state.CanClaim && DateTime.Now < state.ClaimReset)
+                {
+                    Log.Warning($"{guild} {message.Channel}: Found character '{character}' but cannot claim it due to cooldown.");
+                    return;
                 }
 
                 Log.Warning($"{guild} {message.Channel}: Found character '{character}', trying marriage.");

--- a/MudaeFarm/AutoClaimer.cs
+++ b/MudaeFarm/AutoClaimer.cs
@@ -105,20 +105,21 @@ namespace MudaeFarm
             matched |= _config.WishedCharacterRegex?.IsMatch(character) ?? false;
             matched |= _config.WishedAnimeRegex?.IsMatch(anime) ?? false;
 
-            // ensure we can claim right now
             if (matched)
             {
-                var state = _state.Get(guild.Id);
-
-                if (!state.CanClaim && DateTime.Now < state.ClaimReset)
+                // enforce always claiming if state update is disabled
+                if (!string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
                 {
-                    Log.Warning($"{guild} {message.Channel}: Found character '{character}' but cannot claim it due to cooldown.");
-                    return;
-                }
-            }
+                    var state = _state.Get(guild.Id);
 
-            if (matched)
-            {
+                    // ensure we can claim right now
+                    if (!state.CanClaim && DateTime.Now < state.ClaimReset)
+                    {
+                        Log.Warning($"{guild} {message.Channel}: Found character '{character}' but cannot claim it due to cooldown.");
+                        return;
+                    }
+                }
+
                 Log.Warning($"{guild} {message.Channel}: Found character '{character}', trying marriage.");
 
                 // reactions may not have been attached when we received this message

--- a/MudaeFarm/AutoKakera.cs
+++ b/MudaeFarm/AutoKakera.cs
@@ -102,19 +102,23 @@ namespace MudaeFarm
             if (!_config.KakeraTargets.Contains(kakera))
                 return;
 
-            // must have enough kakera power to claim this kakera
-            var state = _state.Get(guildChannel.GuildId);
+            // enforce always claiming if state update is disabled
+            if (!string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
+            {
+                var state = _state.Get(guildChannel.GuildId);
 
-            if (!state.CanKakera)
-                return;
+                // must have enough kakera power to claim this kakera
+                if (!state.CanKakera)
+                    return;
+
+                // update state
+                state.KakeraPower -= state.KakeraConsumption;
+            }
 
             // claim kakera
             await Task.Delay(_config.KakeraClaimDelay);
 
             await message.AddReactionAsync(reaction.Emote);
-
-            // update state
-            state.KakeraPower -= state.KakeraConsumption;
         }
     }
 }

--- a/MudaeFarm/AutoKakera.cs
+++ b/MudaeFarm/AutoKakera.cs
@@ -103,22 +103,19 @@ namespace MudaeFarm
                 return;
 
             // enforce always claiming if state update is disabled
-            if (!string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
-            {
-                var state = _state.Get(guildChannel.GuildId);
+            var state = _state.Get(guildChannel.GuildId);
 
-                // must have enough kakera power to claim this kakera
-                if (!state.CanKakera)
-                    return;
-
-                // update state
-                state.KakeraPower -= state.KakeraConsumption;
-            }
+            // must have enough kakera power to claim this kakera
+            if (!state.CanKakera)
+                return;
 
             // claim kakera
             await Task.Delay(_config.KakeraClaimDelay);
 
             await message.AddReactionAsync(reaction.Emote);
+
+            // update state
+            state.KakeraPower -= state.KakeraConsumption;
         }
     }
 }

--- a/MudaeFarm/AutoRoller.cs
+++ b/MudaeFarm/AutoRoller.cs
@@ -167,7 +167,7 @@ namespace MudaeFarm
 
                             Log.Debug($"{channel.Guild} {channel}: Sent daily kakera command '{_config.DailyKakeraCommand}'.");
 
-                            if (_config.DailyKakeraStateUpdate)
+                            if (_config.DailyKakeraStateUpdate && !string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
                             {
                                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
 

--- a/MudaeFarm/AutoRoller.cs
+++ b/MudaeFarm/AutoRoller.cs
@@ -100,7 +100,7 @@ namespace MudaeFarm
 
                 if (interval == null)
                 {
-                    if (!_config.RollEnabled || state.RollsLeft == 0)
+                    if (!_config.RollEnabled || state.RollsLeft <= 0)
                     {
                         await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
                         continue;

--- a/MudaeFarm/ConfigManager.cs
+++ b/MudaeFarm/ConfigManager.cs
@@ -39,6 +39,7 @@ namespace MudaeFarm
         public string DailyKakeraCommand;
         public bool DailyKakeraStateUpdate;
         public TimeSpan RollTypingDelay;
+        public TimeSpan? RollIntervalOverride;
         public HashSet<ulong> BotChannelIds;
 
         public Regex WishedCharacterRegex;
@@ -224,6 +225,7 @@ namespace MudaeFarm
                 DailyKakeraCommand     = roll.KakeraCommand;
                 DailyKakeraStateUpdate = roll.KakeraStateUpdate;
                 RollTypingDelay        = TimeSpan.FromSeconds(roll.TypingDelay);
+                RollIntervalOverride   = roll.IntervalOverrideMinutes == null ? null as TimeSpan? : TimeSpan.FromMinutes(roll.IntervalOverrideMinutes.Value);
             }
 
             else if (channel.Id == _wishedCharacterChannel.Id)
@@ -410,6 +412,9 @@ namespace MudaeFarm
 
             [JsonProperty("typing_delay_seconds")]
             public double TypingDelay { get; set; } = 0.3;
+
+            [JsonProperty("interval_override_minutes")]
+            public double? IntervalOverrideMinutes { get; set; }
         }
 
 #endregion

--- a/MudaeFarm/MudaeStateManager.cs
+++ b/MudaeFarm/MudaeStateManager.cs
@@ -42,13 +42,6 @@ namespace MudaeFarm
                         state.CanClaim    = true;
                         state.KakeraPower = double.MaxValue;
 
-                        // disable rolls unless an overridden interval is specified
-                        if (_config.RollIntervalOverride != null)
-                        {
-                            state.RollsLeft  = 1;
-                            state.RollsReset = now + _config.RollIntervalOverride.Value;
-                        }
-
                         continue;
                     }
 

--- a/MudaeFarm/MudaeStateManager.cs
+++ b/MudaeFarm/MudaeStateManager.cs
@@ -33,6 +33,9 @@ namespace MudaeFarm
 
                 foreach (var guild in _client.Guilds)
                 {
+                    if (string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
+                        continue;
+
                     var state = Get(guild.Id);
 
                     // enforce refresh every 12 hours

--- a/MudaeFarm/MudaeStateManager.cs
+++ b/MudaeFarm/MudaeStateManager.cs
@@ -33,13 +33,27 @@ namespace MudaeFarm
 
                 foreach (var guild in _client.Guilds)
                 {
-                    if (string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
-                        continue;
-
                     var state = Get(guild.Id);
 
+                    // if state_update_command is disabled, assume the follow state...
+                    if (string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
+                    {
+                        // assume we can always claim rolls or Kakera at any time
+                        state.CanClaim    = true;
+                        state.KakeraPower = double.MaxValue;
+
+                        // disable rolls unless an overridden interval is specified
+                        if (_config.RollIntervalOverride != null)
+                        {
+                            state.RollsLeft  = 1;
+                            state.RollsReset = now + _config.RollIntervalOverride.Value;
+                        }
+
+                        continue;
+                    }
+
                     // enforce refresh every 12 hours
-                    var updateTime = DateTime.Now.AddHours(12);
+                    var updateTime = now.AddHours(12);
 
                     // refresh at the earliest reset time
                     if (!state.CanClaim)

--- a/MudaeFarm/MudaeStateManager.cs
+++ b/MudaeFarm/MudaeStateManager.cs
@@ -35,10 +35,10 @@ namespace MudaeFarm
                 {
                     var state = Get(guild.Id);
 
-                    // if state_update_command is disabled, assume the follow state...
+                    // if state_update_command is disabled, assume...
                     if (string.IsNullOrWhiteSpace(_config.StateUpdateCommand))
                     {
-                        // assume we can always claim rolls or Kakera at any time
+                        // we can always claim rolls or Kakera at any time
                         state.CanClaim    = true;
                         state.KakeraPower = double.MaxValue;
 
@@ -74,7 +74,7 @@ namespace MudaeFarm
                     state.ForceNextRefresh = false;
                 }
 
-                await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ MudaeFarm wishlists are entirely separate from Mudae the wishlist and will not s
 
 ### Miscellaneous
 
-- MudaeFarm will periodically send `$tu` command to determine the claiming cooldown and rolling interval. To disable this behavior, change `state_update_command` to `""`. MudaeFarm will attempt to claim all subsequent matching rolls regardless of cooldown.
+- MudaeFarm will periodically send `$tu` command to determine the claiming cooldown and rolling interval. To disable this behavior, change `state_update_command` to `""`. When disabled, all subsequent matching rolls will be claimed regardless of cooldown.
 - Autorolling is adaptive to the reset time determined by `$tu`. Change `interval_override_minutes` to override the interval in *minutes*.

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ MudaeFarm wishlists are entirely separate from Mudae the wishlist and will not s
 
 ### Miscellaneous
 
-- MudaeFarm will periodically send `$tu` command to determine the claiming cooldown and rolling interval. To disable this behavior, change `state_update_command` to `""`. When disabled, all subsequent matching rolls will be claimed regardless of cooldown.
+- MudaeFarm will periodically send `$tu` command to determine the claiming cooldown and rolling interval. To disable this behavior, change `state_update_command` to `""`. All subsequent matching rolls will be claimed regardless of cooldown and adaptive autorolling will be disabled.
 - Autorolling is adaptive to the reset time determined by `$tu`. Change `interval_override_minutes` to override the interval in *minutes*.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,29 @@ You can bypass the "Windows protected your PC" popup by clicking "More info". Al
 
 ## Usage
 
-On initial run, MudaeFarm will create a dedicated server named `MudaeFarm` for bot configuration. You can edit your wishlists, claiming, rolling and other miscellaneous settings there. It may take a while for this server to be created.
+### Initialization
 
-To configure character/anime wishlists, you can simply send the name of the character/anime in the wishlist channel, separated by individual messages. Names are *case insensitive* and support basic glob expressions like `?` and `*`.
+On initial run, MudaeFarm will create a dedicated server named `MudaeFarm` for bot configuration. You can edit your wishlists, claiming, rolling and other miscellaneous settings there.
+
+It may take a while for this server to be created.
+
+**MudaeFarm is disabled on all servers by default.** You must copy the *ID of the channel* in which you want to enable MudaeFarm (usually the bot/spam channel of that server), and send that ID in `#bot-channels`.
+
+### Configuration
+
+You can edit JSON configuration messages and the bot will reload the changes automatically.
+
+### Wishlists
+
+To configure character/anime wishlists, you can simply send the name of the character/anime in the wishlist channel, separated by individual messages.
+
+Names are *case insensitive* and support basic glob expressions like `?` and `*`.
+
+To remove a character/anime from the wishlist, delete the message itself.
 
 MudaeFarm wishlists are entirely separate from Mudae the wishlist and will not synchronize against each other.
 
-**MudaeFarm is disabled on all servers by default.** You must copy the ID of the channel in which you want to enable MudaeFarm (usually the bot/spam channel of that server), and send that ID in `#bot-channels`.
+### Miscellaneous
 
-For JSON-based configuration messages, you can simply edit the contents and the bot will reload the changes automatically.
-
-Please **do not modify** `state_update_command`!!
+- MudaeFarm will periodically send `$tu` command to determine the claiming cooldown and rolling interval. To disable this behavior, change `state_update_command` to `""`. MudaeFarm will attempt to claim all subsequent matching rolls regardless of cooldown.
+- Autorolling is adaptive to the reset time determined by `$tu`. Change `interval_override_minutes` to override the interval in *minutes*.


### PR DESCRIPTION
Resolves #35 

- Change `state_update_command` to `""` to disable state updates. All subsequent matching rolls will be claimed regardless of cooldown.
- Change `interval_override_minutes` to override the interval in *minutes*.
