### PR TITLE
Catch exceptions from channel.SendMessageAsync

### DIFF
--- a/MudaeFarm/MudaeStateManager.cs
+++ b/MudaeFarm/MudaeStateManager.cs
@@ -72,11 +72,19 @@ namespace MudaeFarm
                     if (channel == null)
                         continue;
 
-                    // send command
-                    await channel.SendMessageAsync(_config.StateUpdateCommand);
+                    try
+                    {
+                        // send command
+                        await channel.SendMessageAsync(_config.StateUpdateCommand);
+
+                        state.LastRefresh = now;
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Warning($"Could not send state update command '{_config.StateUpdateCommand}'.", e);
+                    }
 
                     state.ForceNextRefresh = false;
-                    state.LastRefresh      = now;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);


### PR DESCRIPTION
Partly resolves #50 

Can't fix `MessageReceived` triggering multiple times at this level.