### PR TITLE
Allow bypassing heart emoji check for custom emotes

### DIFF
--- a/MudaeFarm/AutoClaimer.cs
+++ b/MudaeFarm/AutoClaimer.cs
@@ -159,8 +159,8 @@ namespace MudaeFarm
 
             var (message, character, measure) = (x.Message, x.Character, x.Measure);
 
-            // reaction must be a heart emote
-            if (Array.IndexOf(_heartEmotes, reaction.Emote) == -1)
+            // reaction must be a heart emote (checking is disabled if custom emotes are enabled)
+            if (!_config.ClaimCustomEmotes && Array.IndexOf(_heartEmotes, reaction.Emote) == -1)
                 return;
 
             // claim the roll

--- a/MudaeFarm/ConfigManager.cs
+++ b/MudaeFarm/ConfigManager.cs
@@ -34,6 +34,7 @@ namespace MudaeFarm
         public List<string> ClaimReplies;
         public TimeSpan KakeraClaimDelay;
         public HashSet<KakeraType> KakeraTargets;
+        public bool ClaimCustomEmotes;
 
         public bool RollEnabled;
         public string RollCommand;
@@ -229,10 +230,11 @@ namespace MudaeFarm
                 // claiming
                 var claim = await LoadConfigPartAsync(channel, "Claiming", dict, ClaimConfig.CreateDefault);
 
-                ClaimEnabled     = claim.Enabled;
-                ClaimDelay       = TimeSpan.FromSeconds(claim.Delay);
-                KakeraClaimDelay = TimeSpan.FromSeconds(claim.KakeraDelay);
-                KakeraTargets    = claim.KakeraTargets;
+                ClaimEnabled      = claim.Enabled;
+                ClaimDelay        = TimeSpan.FromSeconds(claim.Delay);
+                KakeraClaimDelay  = TimeSpan.FromSeconds(claim.KakeraDelay);
+                KakeraTargets     = claim.KakeraTargets;
+                ClaimCustomEmotes = claim.CustomEmotes;
 
                 // rolling
                 var roll = await LoadConfigPartAsync<RollConfig>(channel, "Rolling", dict);
@@ -418,6 +420,9 @@ namespace MudaeFarm
 
             [JsonProperty("kakera_targets")]
             public HashSet<KakeraType> KakeraTargets { get; set; }
+
+            [JsonProperty("enable_custom_emotes")]
+            public bool CustomEmotes { get; set; }
         }
 
         public class RollConfig

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ To remove a character/anime from the wishlist, delete the message itself.
 
 MudaeFarm wishlists are entirely separate from Mudae the wishlist and will not synchronize against each other.
 
+- If a server has custom emotes instead of hearts for claiming, change `enable_custom_emotes` to `true` in the claiming configuration.
+
 ### Autoreply
 
-MudaeFarm can optionally send a preconfigured reply message when a character is claimed. Selection is random.
+MudaeFarm can optionally send a reply message when a character is claimed. Selection is random.
 
 - `.` represents *not* sending a reply.
 - `\n` splits one selected reply into multiple messages.


### PR DESCRIPTION
Resolves #48 

If a server has custom emotes instead of hearts for claiming, change `enable_custom_emotes` to `true` in the claiming configuration.