### PR TITLE
[MudaeRoller] Option to set max rolls and dk wait time.

### DIFF
--- a/MudaeFarm/MudaeRoller.cs
+++ b/MudaeFarm/MudaeRoller.cs
@@ -189,10 +189,15 @@ namespace MudaeFarm
                         continue;
                     }
                 }
+                else if (response.Content.StartsWith("wished by", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogInformation($"Found a wished character with command '{options.Command}'. Response: {response.Content}. Continuing the rolls.");
+                    continue;
+                }
 
-                _logger.LogWarning($"Could not handle Mudae response for command '{options.Command}'. Assuming a sane default of 5 rolls per hour ({rolls} right now). Response: {response.Content}");
+                _logger.LogWarning($"Could not handle Mudae response for command '{options.Command}'. Assuming a sane default of {options.GlobalMaxRolls} rolls per hour ({rolls} right now). Response: {response.Content}");
 
-                if (rolls >= 5)
+                if (rolls >= options.GlobalMaxRolls)
                 {
                     _logger.LogInformation($"Preemptively finished roll {rolls} of batch {batches} in {logPlace}. Next batch in an hour.");
                     rolls = 0;
@@ -248,7 +253,7 @@ namespace MudaeFarm
                 // dk output doesn't really matter, because we'll have to wait a day anyway
                 _logger.LogInformation($"Claimed daily kakera in {logPlace}.");
 
-                await Task.Delay(TimeSpan.FromDays(1), cancellationToken);
+                await Task.Delay(TimeSpan.FromHours(options.DailyKakeraWaitTime), cancellationToken);
             }
         }
     }

--- a/MudaeFarm/MudaeRoller.cs
+++ b/MudaeFarm/MudaeRoller.cs
@@ -189,15 +189,10 @@ namespace MudaeFarm
                         continue;
                     }
                 }
-                else if (response.Content.StartsWith("wished by", StringComparison.OrdinalIgnoreCase))
-                {
-                    _logger.LogInformation($"Found a wished character with command '{options.Command}'. Response: {response.Content}. Continuing the rolls.");
-                    continue;
-                }
 
                 _logger.LogWarning($"Could not handle Mudae response for command '{options.Command}'. Assuming a sane default of {options.GlobalMaxRolls} rolls per hour ({rolls} right now). Response: {response.Content}");
 
-                if (rolls >= options.GlobalMaxRolls)
+                if (rolls >= options.DefaultPerHour)
                 {
                     _logger.LogInformation($"Preemptively finished roll {rolls} of batch {batches} in {logPlace}. Next batch in an hour.");
                     rolls = 0;
@@ -253,7 +248,7 @@ namespace MudaeFarm
                 // dk output doesn't really matter, because we'll have to wait a day anyway
                 _logger.LogInformation($"Claimed daily kakera in {logPlace}.");
 
-                await Task.Delay(TimeSpan.FromHours(options.DailyKakeraWaitTime), cancellationToken);
+                await Task.Delay(TimeSpan.FromHours(options.DailyKakeraWaitHours), cancellationToken);
             }
         }
     }

--- a/MudaeFarm/Options.cs
+++ b/MudaeFarm/Options.cs
@@ -79,11 +79,11 @@ namespace MudaeFarm
         [JsonProperty("interval_seconds")]
         public double IntervalSeconds { get; set; } = 0.5;
 
-        [JsonProperty("global_max_rolls")]
-        public int GlobalMaxRolls { get; set; } = 5;
+        [JsonProperty("default_per_hour")]
+        public int DefaultPerHour { get; set; } = 5;
 
-        [JsonProperty("daily_kakera_wait_time")]
-        public int DailyKakeraWaitTime { get; set; } = 20;
+        [JsonProperty("daily_kakera_wait_hours")]
+        public int DailyKakeraWaitHours { get; set; } = 20;
     }
 
     public class CharacterWishlist

--- a/MudaeFarm/Options.cs
+++ b/MudaeFarm/Options.cs
@@ -78,6 +78,12 @@ namespace MudaeFarm
 
         [JsonProperty("interval_seconds")]
         public double IntervalSeconds { get; set; } = 0.5;
+
+        [JsonProperty("global_max_rolls")]
+        public int GlobalMaxRolls { get; set; } = 5;
+
+        [JsonProperty("daily_kakera_wait_time")]
+        public int DailyKakeraWaitTime { get; set; } = 20;
     }
 
     public class CharacterWishlist

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Configuration is written in JSON and stored in messages that you can edit at any
     - `daily_kakera_command`: Command to use for rolling daily kakera.
     - `typing_delay_seconds`: Number of seconds to type the rolling command before sending it.
     - `interval_seconds`: Interval in seconds between each roll (not applicable to daily kakera).
-    - `default_per_hour`: Number of rolls that MudaeFarm will perform every hour at minimum.
+    - `default_per_hour`: Number of rolls that MudaeFarm will perform every hour at minimum if it was not able to determine the roll's result.
     - `daily_kakera_wait_hours`: Number of hours that MudaeFarm will wait for between each $dk. (set it to 10 for premium members, 20 for regular)
 
 ### `#wished-characters`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Configuration is written in JSON and stored in messages that you can edit at any
     - `daily_kakera_command`: Command to use for rolling daily kakera.
     - `typing_delay_seconds`: Number of seconds to type the rolling command before sending it.
     - `interval_seconds`: Interval in seconds between each roll (not applicable to daily kakera).
+    - `default_per_hour`: Number of rolls that MudaeFarm will perform every hour at minimum.
+    - `daily_kakera_wait_hours`: Number of hours that MudaeFarm will wait for between each $dk. (set it to 10 for premium members, 20 for regular)
 
 ### `#wished-characters`
 


### PR DESCRIPTION
The max rolls option will be used whenever TryParseRollLimited returns false, or mudae sends a non parsable message

DailyKakeraWaitTime will set the wait time for the $dk command (20 hours by default, 10 hours if premium mudae member)